### PR TITLE
otoczenie nazwy GROUPS backtiskiem

### DIFF
--- a/src/main/java/com/kodilla/ecommercee/domain/Group.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/Group.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "GROUPS")
+@Table(name = "`GROUPS`")
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter


### PR DESCRIPTION
Nazwa GROUPS jest zastrzeżona, dlatego trzeba było użyć backticki.